### PR TITLE
[HOTFIX] 태그 삭제되는 버그 수정

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+
+
 def get_default_img(tags):
     ret = 'share-blog'
     default_img_list = [
@@ -38,7 +41,7 @@ def obj_to_post(obj, flag=True):
     if obj.image:
         post['image'] = obj.image.url
     else:
-        post['image'] = get_default_img(post['tags'])
+        post['image'] = get_default_img(deepcopy(post['tags']))
 
     if obj.update_dt:
         post['update_dt'] = obj.update_dt.strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## 변경 사항
* 참조형 데이터 타입을 전달하여 `pop` 했기 때문에 발생하는 문제
* 깊은 복사 사용해서 해결 (`copy.deepcopy`)