### PR TITLE
[FEAT] request에 user agent 정보 추가

### DIFF
--- a/job.py
+++ b/job.py
@@ -10,6 +10,8 @@ import requests  # noqa
 
 
 class Crawler:
+    header = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36"} # noqa
+
     def _get_selector(self, key):
         return self.selector[key]
 
@@ -73,7 +75,7 @@ class Crawler:
             [post.tags.add(t) for t in self._get_tags(html)]
 
     def _get_html(self, url):
-        res = requests.get(url)
+        res = requests.get(url, headers=self.header)
         return BeautifulSoup(res.content, "html.parser")
 
     def _get_link_list():


### PR DESCRIPTION
## 변경 사항
* velog, tistory에서  포스트들을 크롤링 할 때 [지난 PR](https://github.com/toughhyeok/vue-django-blog/pull/4#issuecomment-1253852999)에서 이야기 했던  문제가 생길 수 있어 [User agent](https://developer.mozilla.org/ko/docs/Glossary/User_agent) 정보 header에 추가


*찾아보니 봇으로 의심되어 저희 운영 서버(AWS - EC2)에서의 크롤링이 블가능 하게 될 수 도 있다고 하네요* 