### PR TITLE
[HOTFIX] pagination filter  버그 수정

### DIFF
--- a/templates/include/post_list_vue.html
+++ b/templates/include/post_list_vue.html
@@ -54,8 +54,8 @@
             fetchPostList(page = 1) {
                 console.log("fetchPostList()...", page, this.category, this.tag);
                 let getUrl = '';
-                if (this.category) getUrl = `/api/post/list/?page=${page}&category=${this.category}`;
-                else if (this.tag) getUrl = `/api/post/list/?page=${page}&tag=${this.tag}`;
+                if (this.category) getUrl = `/api/post/list/?category=${this.category}&page=${page}`;
+                else if (this.tag) getUrl = `/api/post/list/?tags=${this.tag}&page=${page}`;
                 else getUrl = `/api/post/list/?page=${page}`;
                 axios.get(getUrl)
                     .then(res => {


### PR DESCRIPTION
## 변경 사항
* url [query string](https://en.wikipedia.org/wiki/Query_string) 오타 수정
* (참고) 아래 query string의 순서는 상관 없습니다.
```javascript
getUrl = `/api/post/list/?category=${this.category}&page=${page}`
```
```javascript
getUrl = `/api/post/list/?page=${page}&category=${this.category}`
```
