### PR TITLE
[FEAT] github issue-term title

### DIFF
--- a/templates/include/post_detail_vue.html
+++ b/templates/include/post_detail_vue.html
@@ -28,7 +28,7 @@
             console.log("mounted()...");
             let script = document.createElement("script");
             script.setAttribute("src", "https://utteranc.es/client.js");
-            script.setAttribute("issue-term", "pathname");
+            script.setAttribute("issue-term", "title");
             script.setAttribute("repo", "toughhyeok/vue-django-blog");
             script.setAttribute("theme", "github-light");
             script.setAttribute("crossorigin", "anonymous");


### PR DESCRIPTION
## 배경
* utterance github 댓글 기능은 github 이슈 이름과 detail 페이지의 url과 매칭되고 있음.
* issue를 봤을 때 어떤 내용인지 제목으로 구분되지 않음.
<img width="478" alt="image" src="https://user-images.githubusercontent.com/88708976/195995171-75f1f126-750a-4797-86d3-2a28b3c0c512.png">

## 변경 사항
* detail 페이지의 `<title>`이 게시물 제목으로 변경되면서 title로 utterance 댓글이 매칭될 수 있도록 변경
<img width="495" alt="image" src="https://user-images.githubusercontent.com/88708976/195995213-ec3354de-0326-49b0-98d7-c274b9f32893.png">

> **Warning**
> 기존에 있던 issue들의 이름을 모두 수동으로 변경해줘야 합니다.
