### PR TITLE
[HOTFIX] tistory page num bug

### DIFF
--- a/job.py
+++ b/job.py
@@ -96,8 +96,12 @@ class Crawler:
         res = requests.get(url, headers=self.header)
         return BeautifulSoup(res.content, "html.parser")
 
-    def _get_link_list():
-        return None
+    def _get_link_list(self):
+        html = self._get_html(self.base_url + self.category_url)
+        anchors = html.select(self._get_selector("link"))
+        links = [self.base_url + a["href"] for a in anchors]
+        links.reverse()
+        return links
 
     def crawl(self):
         crawl_list = self._get_link_list()
@@ -128,25 +132,6 @@ class HotamulCrawler(Crawler):
     def _get_category_impl(self, html):
         return html.select_one(self._get_selector("category")).text
 
-    def __get_page_nums(self):
-        html = self._get_html(self.base_url + self.category_url)
-        nums = [s.text for s in html.select(self._get_selector("page"))]
-        if len(nums) == 3:
-            return [1, ]
-        return list(range(int(nums[1]), int(nums[-2])))
-
-    def _get_link_list(self):
-        nums = self.__get_page_nums()
-        links = []
-        for n in nums:
-            html = self._get_html(
-                self.base_url + self.category_url + f"?page={n}")
-            anchors = html.select(self._get_selector("link"))
-            for a in anchors:
-                links.append(self.base_url + a["href"])
-        links.reverse()
-        return links
-
 
 class GiruBoyCrawler(Crawler):
     name = "giruboy"
@@ -168,13 +153,6 @@ class GiruBoyCrawler(Crawler):
 
     def _get_category_impl(self, html):
         return self.category_name
-
-    def _get_link_list(self):
-        html = self._get_html(self.base_url + self.category_url)
-        anchors = html.select(self._get_selector("link"))
-        links = [self.base_url + a["href"] for a in anchors]
-        links.reverse()
-        return links
 
 
 def create_crawlers():


### PR DESCRIPTION
## 배경
* 카카오톡 서버 문제로 인해 [hotamul.tistory](https://hotamul.tistory.com/)에 모바일 버전으로만 접속되어 `get_the_latests_blog_post` 500 ERROR 발생.
(모바일 버전으로 접속하게 되면 pagination이 사라짐)

## 변경사항
* 현재 url이 저장되어 있어 최신 페이지인 1페이지만 가져오면 되므로 페이지 크롤링 제거